### PR TITLE
Replace the text-based logo with Cauzality's logo

### DIFF
--- a/Site/main-style.css
+++ b/Site/main-style.css
@@ -28,14 +28,14 @@ body {
 a.scratch{	
 	float: left;
 	display: block;
-	width: 35px;
+	width: 150px;
 	height: 35px;
-	background: url("assets/images/oslogo.png") left center no-repeat;
+	background: url("http://score.mclub.us/os-logotype.svg") left center no-repeat;
 	text-indent: -99999em;
 	padding: 0 2px;
 }
 a.scratch:hover{
-	background: url("assets/images/oslogo.png") left center no-repeat;
+	
 }
 
 .header ul,

--- a/Site/navbar.php
+++ b/Site/navbar.php
@@ -1,6 +1,5 @@
 <div class="header">
-    <div class="container">	<a class="scratch" href="/live/alpha/"></a><a href="/live/alpha/">
-    <span class="logo-name"><b>OPEN</b>SPRITES</span></a>
+    <div class="container">	<a class="scratch" href="/live/alpha/"></a>
 
         <ul class="left">
             <li><a href="">Sprites</a>


### PR DESCRIPTION
Replaced the text-based logo with Cauzality's version (http://score.mclub.us/os-logotype.svg) 
